### PR TITLE
Initialize preprocessor in example befora calling it

### DIFF
--- a/examples/preprocess.py
+++ b/examples/preprocess.py
@@ -1,12 +1,13 @@
 from speechlib import PreProcessor
 
 file = "obama1.mp3"
-
+#initialize
+prep = PreProcessor()
 # convert mp3 to wav
-wav_file = PreProcessor.convert_to_wav(file)   
+wav_file = prep.convert_to_wav(file)   
 
 # convert wav file from stereo to mono
-PreProcessor.convert_to_mono(wav_file)
+prep.convert_to_mono(wav_file)
 
 # re-encode wav file to have 16-bit PCM encoding
-PreProcessor.re_encode(wav_file)
+prep.re_encode(wav_file)


### PR DESCRIPTION
This example fails because the it's calling the class and not an initialized object