### PR TITLE
Update to speechbrain.inference

### DIFF
--- a/speechlib/speaker_recognition.py
+++ b/speechlib/speaker_recognition.py
@@ -1,4 +1,4 @@
-from speechbrain.pretrained import SpeakerRecognition
+from speechbrain.inference import SpeakerRecognition
 import os
 from pydub import AudioSegment
 from collections import defaultdict


### PR DESCRIPTION
speechbrain is not using speechbrain.pretrained since version 0.5.2 . The current version (speechbrain 1.0.0) uses speechbrain.inference instead. It is just a simple change to update references. 

https://github.com/asumagic/speechbrain/commit/6d54ff0a45880c5bb8c83f2592de991b33b08b48